### PR TITLE
revise package dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: rclimateca
 Type: Package
 Title: Fetch Climate Data from Environment Canada
-Version: 1.0.0
-Date: 2018-01-07
+Version: 1.0.1
+Date: 2018-01-17
 Author: Dewey Dunnington <dewey@fishandwhistle.net>
 Maintainer: Dewey Dunnington <dewey@fishandwhistle.net>
 Description: The Environment Canada climate archives <http://climate.weather.gc.ca/>
@@ -13,11 +13,26 @@ Description: The Environment Canada climate archives <http://climate.weather.gc.
   in climate research.
 License: GPL-3
 Depends: R (>= 2.10)
-Imports: digest, httr, prettymapr, reshape2, lubridate, mudata2, 
-    dplyr, stringr, readr, tibble, purrr, tidyr, magrittr, rlang, hms
+Imports: 
+    digest,
+    httr, 
+    prettymapr, 
+    reshape2, 
+    lubridate, 
+    mudata2, 
+    dplyr(>= 0.7.0),
+    stringr, 
+    readr, 
+    tibble, 
+    purrr, 
+    tidyr(>= 0.7.0), 
+    magrittr,
+    rlang
 URL: https://github.com/paleolimbot/rclimateca
 BugReports: https://github.com/paleolimbot/rclimateca/issues
-Suggests: ggplot2, testthat,
+Suggests: 
+    ggplot2, 
+    testthat,
     covr,
     knitr,
     rmarkdown

--- a/R/climate_data.R
+++ b/R/climate_data.R
@@ -531,7 +531,7 @@ ec_climate_parse_dates <- function(climate_df) {
 
     if("time" %in% colnames(df_nice)) {
       # hourly output
-      df_nice$time_lst <- hms::parse_hm(df_nice$time)
+      df_nice$time_lst <- readr::parse_time(df_nice$time, format = "%H:%M")
 
       # it is unclear which time is refered to here, so the column should be removed
       df_nice$time <- NULL


### PR DESCRIPTION
Removed dependence on hms::parse_hms, which only existed in >0.4 ish versions of the package. Added explicit dplyr dependency and tidyr dependency to make sure tidyeval is included.